### PR TITLE
Link to julialang.org -> http instead of https

### DIFF
--- a/script/index.html.head
+++ b/script/index.html.head
@@ -116,7 +116,7 @@
 
 </svg>
 
-        <p>Searchable listing of all <a href="https://github.com/JuliaLang/METADATA.jl">registered packages</a> for the <a href="https://julialang.org">Julia programming language</a>.</p>
+        <p>Searchable listing of all <a href="https://github.com/JuliaLang/METADATA.jl">registered packages</a> for the <a href="http://julialang.org">Julia programming language</a>.</p>
       </div>
 
     <!-- FILTERS -->


### PR DESCRIPTION
julialang.org doesn't support https.
