### PR TITLE
Put version upgrades and icons back in pulse

### DIFF
--- a/img/stars.svg
+++ b/img/stars.svg
@@ -30,7 +30,7 @@ z
    </g>
    <g id="line2d_1">
     <path clip-path="url(#pf6b814eb95)" d="
-M621.874 40.0789
+M621.874 40.0624
 L620.95 40.4245
 L620.026 40.4903
 L619.102 40.9017
@@ -184,7 +184,7 @@ z
 " id="m7fd6d75a0c" style="stroke:#000000;stroke-linejoin:bevel;stroke-width:0.5;"/>
     </defs>
     <g clip-path="url(#pf6b814eb95)">
-     <use style="fill:#ffd700;stroke:#000000;stroke-linejoin:bevel;stroke-width:0.5;" x="621.87375" xlink:href="#m7fd6d75a0c" y="40.078875"/>
+     <use style="fill:#ffd700;stroke:#000000;stroke-linejoin:bevel;stroke-width:0.5;" x="621.87375" xlink:href="#m7fd6d75a0c" y="40.0624178571"/>
      <use style="fill:#ffd700;stroke:#000000;stroke-linejoin:bevel;stroke-width:0.5;" x="620.94990894" xlink:href="#m7fd6d75a0c" y="40.424475"/>
      <use style="fill:#ffd700;stroke:#000000;stroke-linejoin:bevel;stroke-width:0.5;" x="620.026067881" xlink:href="#m7fd6d75a0c" y="40.4903035714"/>
      <use style="fill:#ffd700;stroke:#000000;stroke-linejoin:bevel;stroke-width:0.5;" x="619.102226821" xlink:href="#m7fd6d75a0c" y="40.9017321429"/>

--- a/img/stars.svg
+++ b/img/stars.svg
@@ -30,7 +30,7 @@ z
    </g>
    <g id="line2d_1">
     <path clip-path="url(#pf6b814eb95)" d="
-M621.874 40.0624
+M621.874 40.046
 L620.95 40.4245
 L620.026 40.4903
 L619.102 40.9017
@@ -184,7 +184,7 @@ z
 " id="m7fd6d75a0c" style="stroke:#000000;stroke-linejoin:bevel;stroke-width:0.5;"/>
     </defs>
     <g clip-path="url(#pf6b814eb95)">
-     <use style="fill:#ffd700;stroke:#000000;stroke-linejoin:bevel;stroke-width:0.5;" x="621.87375" xlink:href="#m7fd6d75a0c" y="40.0624178571"/>
+     <use style="fill:#ffd700;stroke:#000000;stroke-linejoin:bevel;stroke-width:0.5;" x="621.87375" xlink:href="#m7fd6d75a0c" y="40.0459607143"/>
      <use style="fill:#ffd700;stroke:#000000;stroke-linejoin:bevel;stroke-width:0.5;" x="620.94990894" xlink:href="#m7fd6d75a0c" y="40.424475"/>
      <use style="fill:#ffd700;stroke:#000000;stroke-linejoin:bevel;stroke-width:0.5;" x="620.026067881" xlink:href="#m7fd6d75a0c" y="40.4903035714"/>
      <use style="fill:#ffd700;stroke:#000000;stroke-linejoin:bevel;stroke-width:0.5;" x="619.102226821" xlink:href="#m7fd6d75a0c" y="40.9017321429"/>

--- a/index.html
+++ b/index.html
@@ -2200,14 +2200,14 @@
     <br>
     Julia v0.4:
     <a href="http://github.com/ApproxFun/BandedMatrices.jl/tree/b0b130b7e3500739f53b021c8105f0f2108d69fe" title="b0b130b7e3500739f53b021c8105f0f2108d69fe">0.0.3</a>
-    (16 hours ago) /
+    (17 hours ago) /
     <span class="statusbox tests_pass"></span>
     <a href="detail/BandedMatrices.html">Tests pass.</a>
     
     <br>
     Julia v0.5:
     <a href="http://github.com/ApproxFun/BandedMatrices.jl/tree/b0b130b7e3500739f53b021c8105f0f2108d69fe" title="b0b130b7e3500739f53b021c8105f0f2108d69fe">0.0.3</a>
-    (16 hours ago) /
+    (17 hours ago) /
     <span class="statusbox tests_pass"></span>
     <a href="detail/BandedMatrices.html">Tests pass.</a>
     
@@ -6666,14 +6666,14 @@ deprecated</span><br>
     <br>
     Julia v0.4:
     <a href="http://github.com/mlubin/ConicNonlinearBridge.jl/tree/ed466ce00374b04a556fa957d2476ae2c0709f79" title="ed466ce00374b04a556fa957d2476ae2c0709f79">0.0.2</a>
-    (14 days ago) /
+    (15 days ago) /
     <span class="statusbox tests_pass"></span>
     <a href="detail/ConicNonlinearBridge.html">Tests pass.</a>
     
     <br>
     Julia v0.5:
     <a href="http://github.com/mlubin/ConicNonlinearBridge.jl/tree/ed466ce00374b04a556fa957d2476ae2c0709f79" title="ed466ce00374b04a556fa957d2476ae2c0709f79">0.0.2</a>
-    (14 days ago) /
+    (15 days ago) /
     <span class="statusbox tests_fail"></span>
     <a href="detail/ConicNonlinearBridge.html">Tests fail.</a>
     
@@ -8990,7 +8990,7 @@ deprecated</span><br>
     Owner: <a href="http://github.com/ChrisRackauckas">ChrisRackauckas</a>
     <br>
     <span title="GitHub stars">
-        5 ★
+        6 ★
     </span> /
     <span title="Number of packages this package depends on">
         29 ↧
@@ -12184,21 +12184,21 @@ deprecated</span><br>
     <br>
     Julia v0.3:
     <a href="http://github.com/JuliaIO/FileIO.jl/tree/9c2c1b5c54627bb67fe0313635a1da8272b2bc50" title="9c2c1b5c54627bb67fe0313635a1da8272b2bc50">0.0.6</a>
-    (16 days ago) /
+    (17 days ago) /
     <span class="statusbox tests_pass"></span>
     <a href="detail/FileIO.html">Tests pass.</a>
     
     <br>
     Julia v0.4:
     <a href="http://github.com/JuliaIO/FileIO.jl/tree/9c2c1b5c54627bb67fe0313635a1da8272b2bc50" title="9c2c1b5c54627bb67fe0313635a1da8272b2bc50">0.0.6</a>
-    (16 days ago) /
+    (17 days ago) /
     <span class="statusbox tests_pass"></span>
     <a href="detail/FileIO.html">Tests pass.</a>
     
     <br>
     Julia v0.5:
     <a href="http://github.com/JuliaIO/FileIO.jl/tree/9c2c1b5c54627bb67fe0313635a1da8272b2bc50" title="9c2c1b5c54627bb67fe0313635a1da8272b2bc50">0.0.6</a>
-    (16 days ago) /
+    (17 days ago) /
     <span class="statusbox tests_pass"></span>
     <a href="detail/FileIO.html">Tests pass.</a>
     
@@ -35061,14 +35061,14 @@ deprecated</span><br>
     <br>
     Julia v0.4:
     <a href="http://github.com/FugroRoames/Rotations.jl/tree/9a5cb5b8b4d2de418f47cc3ee4e1f7ca6c52d004" title="9a5cb5b8b4d2de418f47cc3ee4e1f7ca6c52d004">0.1.0</a>
-    (17 days ago) /
+    (18 days ago) /
     <span class="statusbox tests_pass"></span>
     <a href="detail/Rotations.html">Tests pass.</a>
     
     <br>
     Julia v0.5:
     <a href="http://github.com/FugroRoames/Rotations.jl/tree/9a5cb5b8b4d2de418f47cc3ee4e1f7ca6c52d004" title="9a5cb5b8b4d2de418f47cc3ee4e1f7ca6c52d004">0.1.0</a>
-    (17 days ago) /
+    (18 days ago) /
     <span class="statusbox tests_fail"></span>
     <a href="detail/Rotations.html">Tests fail.</a>
     
@@ -36065,14 +36065,14 @@ deprecated</span><br>
     <br>
     Julia v0.4:
     <a href="http://github.com/cstjean/ScikitLearn.jl/tree/536ae0e69636d348f71acca8908a66986d12108f" title="536ae0e69636d348f71acca8908a66986d12108f">0.0.4</a>
-    (18 days ago) /
+    (19 days ago) /
     <span class="statusbox tests_fail"></span>
     <a href="detail/ScikitLearn.html">Tests fail.</a>
     
     <br>
     Julia v0.5:
     <a href="http://github.com/cstjean/ScikitLearn.jl/tree/536ae0e69636d348f71acca8908a66986d12108f" title="536ae0e69636d348f71acca8908a66986d12108f">0.0.4</a>
-    (18 days ago) /
+    (19 days ago) /
     <span class="statusbox tests_fail"></span>
     <a href="detail/ScikitLearn.html">Tests fail.</a>
     
@@ -40436,7 +40436,7 @@ deprecated</span><br>
     <br>
     Julia v0.4:
     <a href="http://github.com/JuliaStats/TimeSeries.jl/tree/63138d3ac4ebd9c343c0e082d8a45ce17740b95f" title="63138d3ac4ebd9c343c0e082d8a45ce17740b95f">0.8.1</a>
-    (26 days ago) /
+    (27 days ago) /
     <span class="statusbox tests_pass"></span>
     <a href="detail/TimeSeries.html">Tests pass.</a>
     
@@ -40815,14 +40815,14 @@ deprecated</span><br>
     <br>
     Julia v0.4:
     <a href="http://github.com/russolsen/Transit.jl/tree/136b240c0082461b206b32c9f7943b91b1eafeda" title="136b240c0082461b206b32c9f7943b91b1eafeda">0.8.1</a>
-    (10 days ago) /
+    (11 days ago) /
     <span class="statusbox tests_fail"></span>
     <a href="detail/Transit.html">Tests fail.</a>
     
     <br>
     Julia v0.5:
     <a href="http://github.com/russolsen/Transit.jl/tree/136b240c0082461b206b32c9f7943b91b1eafeda" title="136b240c0082461b206b32c9f7943b91b1eafeda">0.8.1</a>
-    (10 days ago) /
+    (11 days ago) /
     <span class="statusbox tests_fail"></span>
     <a href="detail/Transit.html">Tests fail.</a>
     

--- a/index.html
+++ b/index.html
@@ -2200,14 +2200,14 @@
     <br>
     Julia v0.4:
     <a href="http://github.com/ApproxFun/BandedMatrices.jl/tree/b0b130b7e3500739f53b021c8105f0f2108d69fe" title="b0b130b7e3500739f53b021c8105f0f2108d69fe">0.0.3</a>
-    (15 hours ago) /
+    (16 hours ago) /
     <span class="statusbox tests_pass"></span>
     <a href="detail/BandedMatrices.html">Tests pass.</a>
     
     <br>
     Julia v0.5:
     <a href="http://github.com/ApproxFun/BandedMatrices.jl/tree/b0b130b7e3500739f53b021c8105f0f2108d69fe" title="b0b130b7e3500739f53b021c8105f0f2108d69fe">0.0.3</a>
-    (15 hours ago) /
+    (16 hours ago) /
     <span class="statusbox tests_pass"></span>
     <a href="detail/BandedMatrices.html">Tests pass.</a>
     
@@ -8007,14 +8007,14 @@ deprecated</span><br>
     <br>
     Julia v0.4:
     <a href="http://github.com/JuliaStats/DataArrays.jl/tree/2642f6c2bf326d6d932eff06ae2d4ed45fa43999" title="2642f6c2bf326d6d932eff06ae2d4ed45fa43999">0.3.1</a>
-    (9 hours ago) /
+    (11 hours ago) /
     <span class="statusbox tests_pass"></span>
     <a href="detail/DataArrays.html">Tests pass.</a>
     
     <br>
     Julia v0.5:
     <a href="http://github.com/JuliaStats/DataArrays.jl/tree/2642f6c2bf326d6d932eff06ae2d4ed45fa43999" title="2642f6c2bf326d6d932eff06ae2d4ed45fa43999">0.3.1</a>
-    (9 hours ago) /
+    (11 hours ago) /
     <span class="statusbox tests_pass"></span>
     <a href="detail/DataArrays.html">Tests pass.</a>
     
@@ -8616,14 +8616,14 @@ deprecated</span><br>
     <br>
     Julia v0.4:
     <a href="http://github.com/robertdj/Deldir.jl/tree/f647423eb36e29f077d12727290b64f97a4ead9a" title="f647423eb36e29f077d12727290b64f97a4ead9a">0.0.3</a>
-    (21 days ago) /
+    (22 days ago) /
     <span class="statusbox tests_pass"></span>
     <a href="detail/Deldir.html">Tests pass.</a>
     
     <br>
     Julia v0.5:
     <a href="http://github.com/robertdj/Deldir.jl/tree/f647423eb36e29f077d12727290b64f97a4ead9a" title="f647423eb36e29f077d12727290b64f97a4ead9a">0.0.3</a>
-    (21 days ago) /
+    (22 days ago) /
     <span class="statusbox tests_pass"></span>
     <a href="detail/Deldir.html">Tests pass.</a>
     
@@ -9437,14 +9437,14 @@ deprecated</span><br>
     <br>
     Julia v0.4:
     <a href="http://github.com/JuliaStats/Distributions.jl/tree/d1f0b34da0a7e7325c5325b579de42a118b918e5" title="d1f0b34da0a7e7325c5325b579de42a118b918e5">0.9.0</a>
-    (9 days ago) /
+    (10 days ago) /
     <span class="statusbox tests_pass"></span>
     <a href="detail/Distributions.html">Tests pass.</a>
     
     <br>
     Julia v0.5:
     <a href="http://github.com/JuliaStats/Distributions.jl/tree/d1f0b34da0a7e7325c5325b579de42a118b918e5" title="d1f0b34da0a7e7325c5325b579de42a118b918e5">0.9.0</a>
-    (9 days ago) /
+    (10 days ago) /
     <span class="statusbox tests_fail"></span>
     <a href="detail/Distributions.html">Tests fail.</a>
     
@@ -17090,21 +17090,21 @@ deprecated</span><br>
     <br>
     Julia v0.3:
     <a href="http://github.com/JuliaLang/IJulia.jl/tree/fcbcef24d2b022464092c1d0f99555edc27973a0" title="fcbcef24d2b022464092c1d0f99555edc27973a0">1.1.10</a>
-    (11 days ago) /
+    (12 days ago) /
     <span class="statusbox not_possible"></span>
     <a href="detail/IJulia.html">Package was untestable.</a>
     
     <br>
     Julia v0.4:
     <a href="http://github.com/JuliaLang/IJulia.jl/tree/fcbcef24d2b022464092c1d0f99555edc27973a0" title="fcbcef24d2b022464092c1d0f99555edc27973a0">1.1.10</a>
-    (11 days ago) /
+    (12 days ago) /
     <span class="statusbox not_possible"></span>
     <a href="detail/IJulia.html">Package was untestable.</a>
     
     <br>
     Julia v0.5:
     <a href="http://github.com/JuliaLang/IJulia.jl/tree/fcbcef24d2b022464092c1d0f99555edc27973a0" title="fcbcef24d2b022464092c1d0f99555edc27973a0">1.1.10</a>
-    (11 days ago) /
+    (12 days ago) /
     <span class="statusbox not_possible"></span>
     <a href="detail/IJulia.html">Package was untestable.</a>
     
@@ -28962,14 +28962,14 @@ deprecated</span><br>
     <br>
     Julia v0.4:
     <a href="http://github.com/OpenGene/OpenGene.jl/tree/318ae8d2815b27bf0c688b8b4d7566206ce81a63" title="318ae8d2815b27bf0c688b8b4d7566206ce81a63">0.1.8</a>
-    (29 days ago) /
+    (a month ago) /
     <span class="statusbox tests_pass"></span>
     <a href="detail/OpenGene.html">Tests pass.</a>
     
     <br>
     Julia v0.5:
     <a href="http://github.com/OpenGene/OpenGene.jl/tree/318ae8d2815b27bf0c688b8b4d7566206ce81a63" title="318ae8d2815b27bf0c688b8b4d7566206ce81a63">0.1.8</a>
-    (29 days ago) /
+    (a month ago) /
     <span class="statusbox tests_pass"></span>
     <a href="detail/OpenGene.html">Tests pass.</a>
     
@@ -34845,14 +34845,14 @@ deprecated</span><br>
     <br>
     Julia v0.4:
     <a href="http://github.com/FugroRoames/RobustLeastSquares.jl/tree/2856fbbb1631523777e58d102b5eb5f328b87f20" title="2856fbbb1631523777e58d102b5eb5f328b87f20">0.0.1</a>
-    (26 days ago) /
+    (27 days ago) /
     <span class="statusbox tests_pass"></span>
     <a href="detail/RobustLeastSquares.html">Tests pass.</a>
     
     <br>
     Julia v0.5:
     <a href="http://github.com/FugroRoames/RobustLeastSquares.jl/tree/2856fbbb1631523777e58d102b5eb5f328b87f20" title="2856fbbb1631523777e58d102b5eb5f328b87f20">0.0.1</a>
-    (26 days ago) /
+    (27 days ago) /
     <span class="statusbox tests_pass"></span>
     <a href="detail/RobustLeastSquares.html">Tests pass.</a>
     
@@ -41489,7 +41489,7 @@ deprecated</span><br>
     Owner: <a href="http://github.com/JuliaComputing">JuliaComputing</a>
     <br>
     <span title="GitHub stars">
-        12 ★
+        13 ★
     </span> /
     <span title="Number of packages this package depends on">
         0 ↧
@@ -41763,14 +41763,14 @@ deprecated</span><br>
     <br>
     Julia v0.4:
     <a href="http://github.com/dpsanders/ValidatedNumerics.jl/tree/67f3b9aa91d20743256bcd841d89bb8b6b5b4920" title="67f3b9aa91d20743256bcd841d89bb8b6b5b4920">0.4.2</a>
-    (13 hours ago) /
+    (15 hours ago) /
     <span class="statusbox tests_pass"></span>
     <a href="detail/ValidatedNumerics.html">Tests pass.</a>
     
     <br>
     Julia v0.5:
     <a href="http://github.com/dpsanders/ValidatedNumerics.jl/tree/67f3b9aa91d20743256bcd841d89bb8b6b5b4920" title="67f3b9aa91d20743256bcd841d89bb8b6b5b4920">0.4.2</a>
-    (13 hours ago) /
+    (15 hours ago) /
     <span class="statusbox tests_pass"></span>
     <a href="detail/ValidatedNumerics.html">Tests pass.</a>
     

--- a/pulse.html
+++ b/pulse.html
@@ -91,16 +91,10 @@
             <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;peterkovesi&#x2F;ImageProjectiveGeometry.jl/tree/b47f688fa0b4fc582b049fb018cf6e36896e8e38">0.1.0</a> </td>
           </tr>
           
-        </table>
-      </div>
-      <div class="col-sm-6" style="text-align:center">
-        <table class="changes" style="margin: 0 auto;">
-          
           <tr>
             <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;rdeits&#x2F;LCMGL.jl">LCMGL</a> </td>
             <td>  </td>
             <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;rdeits&#x2F;LCMGL.jl/tree/36d9d3ad03d6e7b36085e7dceec55a1cfe4a0621">0.0.1</a> </td>
-          </tr>
           </tr>
           
           <tr>
@@ -108,12 +102,122 @@
             <td>  </td>
             <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;JuliaPOMDP&#x2F;POMDPs.jl/tree/cc3307699ecf3f257c9eeaf14a38b2c8af609d2d">0.2.1</a> </td>
           </tr>
-          </tr>
           
           <tr>
             <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;leclere&#x2F;StochDynamicProgramming.jl">StochDynamicProgramming</a> </td>
             <td>  </td>
             <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;leclere&#x2F;StochDynamicProgramming.jl/tree/c035625b1b1946e4551dab9f5b30d1cedcddb1f1">0.1.1</a> </td>
+          </tr>
+          
+          <tr>
+            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;ApproxFun&#x2F;BandedMatrices.jl">BandedMatrices</a> </td>
+            <td> 0.0.2 → </td>
+            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;ApproxFun&#x2F;BandedMatrices.jl/tree/b0b130b7e3500739f53b021c8105f0f2108d69fe">0.0.3</a> </td>
+          </tr>
+          
+          <tr>
+            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;JuliaLang&#x2F;Compat.jl">Compat</a> </td>
+            <td> 0.7.18 → </td>
+            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;JuliaLang&#x2F;Compat.jl/tree/b2bb3abe8057793f44d48ebce9f05c23d3dbcd69">0.7.20</a> </td>
+          </tr>
+          
+          <tr>
+            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;JuliaStats&#x2F;DataArrays.jl">DataArrays</a> </td>
+            <td> 0.3.0 → </td>
+            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;JuliaStats&#x2F;DataArrays.jl/tree/2642f6c2bf326d6d932eff06ae2d4ed45fa43999">0.3.1</a> </td>
+          </tr>
+          
+          <tr>
+            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;JuliaStats&#x2F;DataFrames.jl">DataFrames</a> </td>
+            <td> 0.7.2 → </td>
+            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;JuliaStats&#x2F;DataFrames.jl/tree/fa09067cdf8adec9170384b5883f57ae19ca1219">0.7.3</a> </td>
+          </tr>
+          
+          <tr>
+            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;davidanthoff&#x2F;ExcelReaders.jl">ExcelReaders</a> </td>
+            <td> 0.4.1 → </td>
+            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;davidanthoff&#x2F;ExcelReaders.jl/tree/398738ccdf5111b05782f0f523197b2fd950d429">0.5.0</a> </td>
+          </tr>
+          
+        </table>
+      </div>
+      <div class="col-sm-6" style="text-align:center">
+        <table class="changes" style="margin: 0 auto;">
+          
+          <tr>
+            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;BioJulia&#x2F;IndexableBitVectors.jl">IndexableBitVectors</a> </td>
+            <td> 0.1.0 → </td>
+            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;BioJulia&#x2F;IndexableBitVectors.jl/tree/1ce6e0847ecdb3d63faf9b2b8330a392c75e7a1a">0.1.1</a> </td>
+          </tr>
+          </tr>
+          
+          <tr>
+            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;JuliaLang&#x2F;JSON.jl">JSON</a> </td>
+            <td> 0.5.0 → </td>
+            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;JuliaLang&#x2F;JSON.jl/tree/6df70b0542a2610ad738156cae344fede25d4ccb">0.5.1</a> </td>
+          </tr>
+          </tr>
+          
+          <tr>
+            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;madsjulia&#x2F;Mads.jl">Mads</a> </td>
+            <td> 0.1.11 → </td>
+            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;madsjulia&#x2F;Mads.jl/tree/493b9eed78de6a9e10c3765b7bbc8ae9b5fd68be">0.1.12</a> </td>
+          </tr>
+          </tr>
+          
+          <tr>
+            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;brian-j-smith&#x2F;Mamba.jl">Mamba</a> </td>
+            <td> 0.9.0 → </td>
+            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;brian-j-smith&#x2F;Mamba.jl/tree/8cdba6583cce552f12640fe9c187fe29bf3e31bc">0.9.1</a> </td>
+          </tr>
+          </tr>
+          
+          <tr>
+            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;JuliaSparse&#x2F;Pardiso.jl">Pardiso</a> </td>
+            <td> 0.0.2 → </td>
+            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;JuliaSparse&#x2F;Pardiso.jl/tree/08ce1324bf06e315420e8ddbbfb6f952dc60dffd">0.1.2</a> </td>
+          </tr>
+          </tr>
+          
+          <tr>
+            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;giordano&#x2F;PolynomialRoots.jl">PolynomialRoots</a> </td>
+            <td> 0.0.2 → </td>
+            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;giordano&#x2F;PolynomialRoots.jl/tree/2ff987acfe1f023359ced71bd73b2aaa8dd19de3">0.0.3</a> </td>
+          </tr>
+          </tr>
+          
+          <tr>
+            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;heliosdrm&#x2F;RecurrenceAnalysis.jl">RecurrenceAnalysis</a> </td>
+            <td> 0.0.1 → </td>
+            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;heliosdrm&#x2F;RecurrenceAnalysis.jl/tree/77365344fc73b9b0c7a28da6ee9501edcf5a4491">0.0.2</a> </td>
+          </tr>
+          </tr>
+          
+          <tr>
+            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;lobingera&#x2F;Rsvg.jl">Rsvg</a> </td>
+            <td> 0.0.1 → </td>
+            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;lobingera&#x2F;Rsvg.jl/tree/d8374212dc7cd006a490ac596ce7a53f3fa77308">0.0.2</a> </td>
+          </tr>
+          </tr>
+          
+          <tr>
+            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;dysonance&#x2F;Temporal.jl">Temporal</a> </td>
+            <td> 0.0.2 → </td>
+            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;dysonance&#x2F;Temporal.jl/tree/ee13827c58355bfb7ddbe36eb84415a31e966474">0.0.3</a> </td>
+          </tr>
+          </tr>
+          
+          <tr>
+            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;FugroRoames&#x2F;TypedTables.jl">TypedTables</a> </td>
+            <td> 0.0.4 → </td>
+            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;FugroRoames&#x2F;TypedTables.jl/tree/9570e5f2e21a3276015f0f8a9371c86f940ea255">0.0.5</a> </td>
+          </tr>
+          </tr>
+          
+          <tr>
+            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;dpsanders&#x2F;ValidatedNumerics.jl">ValidatedNumerics</a> </td>
+            <td> 0.4.0 → </td>
+            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;dpsanders&#x2F;ValidatedNumerics.jl/tree/67f3b9aa91d20743256bcd841d89bb8b6b5b4920">0.4.2</a> </td>
           </tr>
           </tr>
           

--- a/pulse.html
+++ b/pulse.html
@@ -68,73 +68,85 @@
         <table class="changes" style="margin: 0 auto;">
           
           <tr>
-            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;JuliaComputing&#x2F;ArrayFire.jl">ArrayFire</a> </td>
+            <td> <span class="glyphicon glyphicon-star"></span>
+                 <a href="http:&#x2F;&#x2F;github.com&#x2F;JuliaComputing&#x2F;ArrayFire.jl">ArrayFire</a> </td>
             <td>  </td>
             <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;JuliaComputing&#x2F;ArrayFire.jl/tree/2ab8171b90b0c5c9d8d9fa7d15373c8d8c199558">0.0.1</a> </td>
           </tr>
           
           <tr>
-            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;ChrisRackauckas&#x2F;GrowableArrays.jl">GrowableArrays</a> </td>
+            <td> <span class="glyphicon glyphicon-star"></span>
+                 <a href="http:&#x2F;&#x2F;github.com&#x2F;ChrisRackauckas&#x2F;GrowableArrays.jl">GrowableArrays</a> </td>
             <td>  </td>
             <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;ChrisRackauckas&#x2F;GrowableArrays.jl/tree/db07ee44ec939afb866c04a5fd1edb18bf92f781">0.0.1</a> </td>
           </tr>
           
           <tr>
-            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;sorpaas&#x2F;HTTP2.jl">HTTP2</a> </td>
+            <td> <span class="glyphicon glyphicon-star"></span>
+                 <a href="http:&#x2F;&#x2F;github.com&#x2F;sorpaas&#x2F;HTTP2.jl">HTTP2</a> </td>
             <td>  </td>
             <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;sorpaas&#x2F;HTTP2.jl/tree/f5b0f8464c086fa7cbe1f44f9b37bc8270f3b921">0.0.1</a> </td>
           </tr>
           
           <tr>
-            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;peterkovesi&#x2F;ImageProjectiveGeometry.jl">ImageProjectiveGeometry</a> </td>
+            <td> <span class="glyphicon glyphicon-star"></span>
+                 <a href="http:&#x2F;&#x2F;github.com&#x2F;peterkovesi&#x2F;ImageProjectiveGeometry.jl">ImageProjectiveGeometry</a> </td>
             <td>  </td>
             <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;peterkovesi&#x2F;ImageProjectiveGeometry.jl/tree/b47f688fa0b4fc582b049fb018cf6e36896e8e38">0.1.0</a> </td>
           </tr>
           
           <tr>
-            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;rdeits&#x2F;LCMGL.jl">LCMGL</a> </td>
+            <td> <span class="glyphicon glyphicon-star"></span>
+                 <a href="http:&#x2F;&#x2F;github.com&#x2F;rdeits&#x2F;LCMGL.jl">LCMGL</a> </td>
             <td>  </td>
             <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;rdeits&#x2F;LCMGL.jl/tree/36d9d3ad03d6e7b36085e7dceec55a1cfe4a0621">0.0.1</a> </td>
           </tr>
           
           <tr>
-            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;JuliaPOMDP&#x2F;POMDPs.jl">POMDPs</a> </td>
+            <td> <span class="glyphicon glyphicon-star"></span>
+                 <a href="http:&#x2F;&#x2F;github.com&#x2F;JuliaPOMDP&#x2F;POMDPs.jl">POMDPs</a> </td>
             <td>  </td>
             <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;JuliaPOMDP&#x2F;POMDPs.jl/tree/cc3307699ecf3f257c9eeaf14a38b2c8af609d2d">0.2.1</a> </td>
           </tr>
           
           <tr>
-            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;leclere&#x2F;StochDynamicProgramming.jl">StochDynamicProgramming</a> </td>
+            <td> <span class="glyphicon glyphicon-star"></span>
+                 <a href="http:&#x2F;&#x2F;github.com&#x2F;leclere&#x2F;StochDynamicProgramming.jl">StochDynamicProgramming</a> </td>
             <td>  </td>
             <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;leclere&#x2F;StochDynamicProgramming.jl/tree/c035625b1b1946e4551dab9f5b30d1cedcddb1f1">0.1.1</a> </td>
           </tr>
           
           <tr>
-            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;ApproxFun&#x2F;BandedMatrices.jl">BandedMatrices</a> </td>
+            <td> <span class="glyphicon glyphicon-arrow-up"></span>
+                 <a href="http:&#x2F;&#x2F;github.com&#x2F;ApproxFun&#x2F;BandedMatrices.jl">BandedMatrices</a> </td>
             <td> 0.0.2 → </td>
             <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;ApproxFun&#x2F;BandedMatrices.jl/tree/b0b130b7e3500739f53b021c8105f0f2108d69fe">0.0.3</a> </td>
           </tr>
           
           <tr>
-            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;JuliaLang&#x2F;Compat.jl">Compat</a> </td>
+            <td> <span class="glyphicon glyphicon-arrow-up"></span>
+                 <a href="http:&#x2F;&#x2F;github.com&#x2F;JuliaLang&#x2F;Compat.jl">Compat</a> </td>
             <td> 0.7.18 → </td>
             <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;JuliaLang&#x2F;Compat.jl/tree/b2bb3abe8057793f44d48ebce9f05c23d3dbcd69">0.7.20</a> </td>
           </tr>
           
           <tr>
-            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;JuliaStats&#x2F;DataArrays.jl">DataArrays</a> </td>
+            <td> <span class="glyphicon glyphicon-arrow-up"></span>
+                 <a href="http:&#x2F;&#x2F;github.com&#x2F;JuliaStats&#x2F;DataArrays.jl">DataArrays</a> </td>
             <td> 0.3.0 → </td>
             <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;JuliaStats&#x2F;DataArrays.jl/tree/2642f6c2bf326d6d932eff06ae2d4ed45fa43999">0.3.1</a> </td>
           </tr>
           
           <tr>
-            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;JuliaStats&#x2F;DataFrames.jl">DataFrames</a> </td>
+            <td> <span class="glyphicon glyphicon-arrow-up"></span>
+                 <a href="http:&#x2F;&#x2F;github.com&#x2F;JuliaStats&#x2F;DataFrames.jl">DataFrames</a> </td>
             <td> 0.7.2 → </td>
             <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;JuliaStats&#x2F;DataFrames.jl/tree/fa09067cdf8adec9170384b5883f57ae19ca1219">0.7.3</a> </td>
           </tr>
           
           <tr>
-            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;davidanthoff&#x2F;ExcelReaders.jl">ExcelReaders</a> </td>
+            <td> <span class="glyphicon glyphicon-arrow-up"></span>
+                 <a href="http:&#x2F;&#x2F;github.com&#x2F;davidanthoff&#x2F;ExcelReaders.jl">ExcelReaders</a> </td>
             <td> 0.4.1 → </td>
             <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;davidanthoff&#x2F;ExcelReaders.jl/tree/398738ccdf5111b05782f0f523197b2fd950d429">0.5.0</a> </td>
           </tr>
@@ -145,77 +157,88 @@
         <table class="changes" style="margin: 0 auto;">
           
           <tr>
-            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;BioJulia&#x2F;IndexableBitVectors.jl">IndexableBitVectors</a> </td>
+            <td> <span class="glyphicon glyphicon-arrow-up"></span>
+                 <a href="http:&#x2F;&#x2F;github.com&#x2F;BioJulia&#x2F;IndexableBitVectors.jl">IndexableBitVectors</a> </td>
             <td> 0.1.0 → </td>
             <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;BioJulia&#x2F;IndexableBitVectors.jl/tree/1ce6e0847ecdb3d63faf9b2b8330a392c75e7a1a">0.1.1</a> </td>
           </tr>
           </tr>
           
           <tr>
-            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;JuliaLang&#x2F;JSON.jl">JSON</a> </td>
+            <td> <span class="glyphicon glyphicon-arrow-up"></span>
+                 <a href="http:&#x2F;&#x2F;github.com&#x2F;JuliaLang&#x2F;JSON.jl">JSON</a> </td>
             <td> 0.5.0 → </td>
             <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;JuliaLang&#x2F;JSON.jl/tree/6df70b0542a2610ad738156cae344fede25d4ccb">0.5.1</a> </td>
           </tr>
           </tr>
           
           <tr>
-            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;madsjulia&#x2F;Mads.jl">Mads</a> </td>
+            <td> <span class="glyphicon glyphicon-arrow-up"></span>
+                 <a href="http:&#x2F;&#x2F;github.com&#x2F;madsjulia&#x2F;Mads.jl">Mads</a> </td>
             <td> 0.1.11 → </td>
             <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;madsjulia&#x2F;Mads.jl/tree/493b9eed78de6a9e10c3765b7bbc8ae9b5fd68be">0.1.12</a> </td>
           </tr>
           </tr>
           
           <tr>
-            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;brian-j-smith&#x2F;Mamba.jl">Mamba</a> </td>
+            <td> <span class="glyphicon glyphicon-arrow-up"></span>
+                 <a href="http:&#x2F;&#x2F;github.com&#x2F;brian-j-smith&#x2F;Mamba.jl">Mamba</a> </td>
             <td> 0.9.0 → </td>
             <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;brian-j-smith&#x2F;Mamba.jl/tree/8cdba6583cce552f12640fe9c187fe29bf3e31bc">0.9.1</a> </td>
           </tr>
           </tr>
           
           <tr>
-            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;JuliaSparse&#x2F;Pardiso.jl">Pardiso</a> </td>
+            <td> <span class="glyphicon glyphicon-arrow-up"></span>
+                 <a href="http:&#x2F;&#x2F;github.com&#x2F;JuliaSparse&#x2F;Pardiso.jl">Pardiso</a> </td>
             <td> 0.0.2 → </td>
             <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;JuliaSparse&#x2F;Pardiso.jl/tree/08ce1324bf06e315420e8ddbbfb6f952dc60dffd">0.1.2</a> </td>
           </tr>
           </tr>
           
           <tr>
-            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;giordano&#x2F;PolynomialRoots.jl">PolynomialRoots</a> </td>
+            <td> <span class="glyphicon glyphicon-arrow-up"></span>
+                 <a href="http:&#x2F;&#x2F;github.com&#x2F;giordano&#x2F;PolynomialRoots.jl">PolynomialRoots</a> </td>
             <td> 0.0.2 → </td>
             <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;giordano&#x2F;PolynomialRoots.jl/tree/2ff987acfe1f023359ced71bd73b2aaa8dd19de3">0.0.3</a> </td>
           </tr>
           </tr>
           
           <tr>
-            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;heliosdrm&#x2F;RecurrenceAnalysis.jl">RecurrenceAnalysis</a> </td>
+            <td> <span class="glyphicon glyphicon-arrow-up"></span>
+                 <a href="http:&#x2F;&#x2F;github.com&#x2F;heliosdrm&#x2F;RecurrenceAnalysis.jl">RecurrenceAnalysis</a> </td>
             <td> 0.0.1 → </td>
             <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;heliosdrm&#x2F;RecurrenceAnalysis.jl/tree/77365344fc73b9b0c7a28da6ee9501edcf5a4491">0.0.2</a> </td>
           </tr>
           </tr>
           
           <tr>
-            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;lobingera&#x2F;Rsvg.jl">Rsvg</a> </td>
+            <td> <span class="glyphicon glyphicon-arrow-up"></span>
+                 <a href="http:&#x2F;&#x2F;github.com&#x2F;lobingera&#x2F;Rsvg.jl">Rsvg</a> </td>
             <td> 0.0.1 → </td>
             <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;lobingera&#x2F;Rsvg.jl/tree/d8374212dc7cd006a490ac596ce7a53f3fa77308">0.0.2</a> </td>
           </tr>
           </tr>
           
           <tr>
-            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;dysonance&#x2F;Temporal.jl">Temporal</a> </td>
+            <td> <span class="glyphicon glyphicon-arrow-up"></span>
+                 <a href="http:&#x2F;&#x2F;github.com&#x2F;dysonance&#x2F;Temporal.jl">Temporal</a> </td>
             <td> 0.0.2 → </td>
             <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;dysonance&#x2F;Temporal.jl/tree/ee13827c58355bfb7ddbe36eb84415a31e966474">0.0.3</a> </td>
           </tr>
           </tr>
           
           <tr>
-            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;FugroRoames&#x2F;TypedTables.jl">TypedTables</a> </td>
+            <td> <span class="glyphicon glyphicon-arrow-up"></span>
+                 <a href="http:&#x2F;&#x2F;github.com&#x2F;FugroRoames&#x2F;TypedTables.jl">TypedTables</a> </td>
             <td> 0.0.4 → </td>
             <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;FugroRoames&#x2F;TypedTables.jl/tree/9570e5f2e21a3276015f0f8a9371c86f940ea255">0.0.5</a> </td>
           </tr>
           </tr>
           
           <tr>
-            <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;dpsanders&#x2F;ValidatedNumerics.jl">ValidatedNumerics</a> </td>
+            <td> <span class="glyphicon glyphicon-arrow-up"></span>
+                 <a href="http:&#x2F;&#x2F;github.com&#x2F;dpsanders&#x2F;ValidatedNumerics.jl">ValidatedNumerics</a> </td>
             <td> 0.4.0 → </td>
             <td> <a href="http:&#x2F;&#x2F;github.com&#x2F;dpsanders&#x2F;ValidatedNumerics.jl/tree/67f3b9aa91d20743256bcd841d89bb8b6b5b4920">0.4.2</a> </td>
           </tr>


### PR DESCRIPTION
Dunno why @IainNZ took out the version upgrades in https://github.com/JuliaCI/PackageEvaluator.jl/commit/9181399b803a8bb1a6aebabaad431df20c1920c8#diff-79c40b084dd57fc42c7b391cb325daddR103 and the icons in https://github.com/JuliaCI/PackageEvaluator.jl/commit/3505a9234d31e238c2eecc0c800f5b68c26db188#diff-7b4885d57b27dafe0fc423c97a5ef4fcL71, but I liked them so went and put them back. Maybe when pkgeval was running closer to monthly than daily it would have been too noisy?
